### PR TITLE
Add LLM judge backend with dynamic selection capability- Implement ju…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# PhishGuard Environment Configuration Template
+# Copy this file to .env and customize the values for your environment
+
+# =============================================================================
+# Judge Service Configuration
+# =============================================================================
+
+# Judge backend: stub | llm
+# - stub: Use the local deterministic rule-based judge
+# - llm: Use LLM-based judge via Ollama
+JUDGE_BACKEND=stub
+
+# LLM Judge Configuration (only used when JUDGE_BACKEND=llm)
+OLLAMA_HOST=http://localhost:11434
+JUDGE_MODEL=llama3.2:1b
+JUDGE_TIMEOUT_SECS=12
+
+# =============================================================================
+# MongoDB Audit Logging (Optional)
+# =============================================================================
+
+# MongoDB connection string for audit logging
+# Leave empty to disable audit logging
+MONGO_URI=
+
+# MongoDB database name for audit logs
+MONGO_DB=phishguard
+
+# =============================================================================
+# Thresholds Configuration
+# =============================================================================
+
+# Path to thresholds JSON file
+# If not set, will look for default threshold files
+THRESHOLDS_JSON=

--- a/scripts/smoke_judge_selector.py
+++ b/scripts/smoke_judge_selector.py
@@ -1,0 +1,27 @@
+import json
+import os
+
+from common.thresholds import load_thresholds
+from gateway.judge_wire import decide_with_judge
+
+# Set backend AFTER imports but before use
+os.environ["JUDGE_BACKEND"] = (
+    "llm"  # set BEFORE judge_wire usage so it binds LLM adapter
+)
+
+TH = load_thresholds(os.getenv("THRESHOLDS_JSON", "configs/dev/thresholds.json"))
+out = decide_with_judge("http://ex.com/login?acct=12345", p_malicious=0.45, th=TH)
+
+print(
+    json.dumps(
+        {
+            "final_decision": out.final_decision,
+            "reason": out.policy_reason,
+            "judge_backend": (
+                None if out.judge is None else out.judge.context.get("backend")
+            ),
+            "judge_verdict": (None if out.judge is None else out.judge.verdict),
+        },
+        indent=2,
+    )
+)

--- a/src/judge_svc/adapter.py
+++ b/src/judge_svc/adapter.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Tuple
+
+import requests  # type: ignore
+
+from judge_svc.contracts import JudgeRequest, JudgeResponse, JudgeVerdict
+from judge_svc.stub import judge_url as fallback_stub  # fail-open if LLM not available
+
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+JUDGE_MODEL = os.getenv("JUDGE_MODEL", "llama3.2:1b")
+JUDGE_TIMEOUT = float(os.getenv("JUDGE_TIMEOUT_SECS", "12"))
+
+_VERDICT_RE = re.compile(r"\bVERDICT\s*:\s*(LEAN_PHISH|LEAN_LEGIT|UNCERTAIN)\b", re.I)
+_SCORE_RE = re.compile(r"\bSCORE\s*:\s*(0(?:\.\d+)?|1(?:\.0+)?)\b", re.I)
+_RAT_RE = re.compile(r"\bRATIONALE\s*:\s*(.+)", re.I | re.S)
+
+
+def _prompt(req: JudgeRequest) -> str:
+    # Compact, deterministic prompt; instruct to emit explicit fields we can parse.
+    feat = req.features.model_dump()
+    return (
+        "You are a security analyst. Assess phishing risk from the URL and "
+        "compact URL-only features.\n"
+        "Respond with EXACTLY three fields on separate lines:\n"
+        "VERDICT: LEAN_PHISH | LEAN_LEGIT | UNCERTAIN\n"
+        "SCORE: number in [0,1]\n"
+        "RATIONALE: brief human explanation\n\n"
+        f"URL: {req.url}\n"
+        f"FEATURES_JSON: {json.dumps(feat, separators=(',',':'))}\n"
+        "Consider length, digit ratio, subdomains, TLD prior, and any "
+        "suspicious tokens in the URL."
+    )
+
+
+def _parse(text: str) -> Tuple[JudgeVerdict, float | None, str]:
+    verdict: JudgeVerdict = "UNCERTAIN"
+    score = None
+    rationale = "no rationale"
+    m = _VERDICT_RE.search(text)
+    if m:
+        v = m.group(1).upper()
+        verdict = (
+            "LEAN_PHISH"
+            if v == "LEAN_PHISH"
+            else ("LEAN_LEGIT" if v == "LEAN_LEGIT" else "UNCERTAIN")
+        )
+    m = _SCORE_RE.search(text)
+    if m:
+        try:
+            score = float(m.group(1))
+            score = max(0.0, min(1.0, score))
+        except Exception:
+            score = None
+    m = _RAT_RE.search(text)
+    if m:
+        rationale = m.group(1).strip().splitlines()[0][:500]
+    return verdict, score, rationale
+
+
+def judge_url_llm(req: JudgeRequest) -> JudgeResponse:
+    """
+    LLM-backed judge using Ollama /api/generate.
+    Fails open to deterministic stub if any network/model error occurs.
+    """
+    try:
+        resp = requests.post(
+            f"{OLLAMA_HOST}/api/generate",
+            json={"model": JUDGE_MODEL, "prompt": _prompt(req), "stream": False},
+            timeout=JUDGE_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        text = data.get("response", "")
+        verdict, score, rationale = _parse(text)
+        return JudgeResponse(
+            verdict=verdict,
+            judge_score=score,
+            rationale=rationale,
+            context={
+                "backend": "llm",
+                "model": JUDGE_MODEL,
+                **req.features.model_dump(),
+            },
+        )
+    except Exception:
+        # Fail-open: never block the request path just because LLM isn't available
+        fb = fallback_stub(req)
+        fb.context.update({"backend": "stub_fallback", "model": JUDGE_MODEL})
+        return fb

--- a/tests/test_gateway_judge_wire.py
+++ b/tests/test_gateway_judge_wire.py
@@ -35,14 +35,14 @@ def test_review_calls_judge_and_maps(monkeypatch):
                 context=self.context,
             )
 
-    monkeypatch.setattr(gateway.judge_wire, "judge_url", lambda req: JR("LEAN_PHISH"))
+    monkeypatch.setattr(gateway.judge_wire, "_JUDGE_FN", lambda req: JR("LEAN_PHISH"))
     out = decide_with_judge("http://foo/login", p_malicious=0.45, th=TH)
     assert out.final_decision == "BLOCK"
 
-    monkeypatch.setattr(gateway.judge_wire, "judge_url", lambda req: JR("LEAN_LEGIT"))
+    monkeypatch.setattr(gateway.judge_wire, "_JUDGE_FN", lambda req: JR("LEAN_LEGIT"))
     out = decide_with_judge("http://foo/login", p_malicious=0.45, th=TH)
     assert out.final_decision == "ALLOW"
 
-    monkeypatch.setattr(gateway.judge_wire, "judge_url", lambda req: JR("UNCERTAIN"))
+    monkeypatch.setattr(gateway.judge_wire, "_JUDGE_FN", lambda req: JR("UNCERTAIN"))
     out = decide_with_judge("http://foo/login", p_malicious=0.45, th=TH)
     assert out.final_decision == "REVIEW"

--- a/tests/test_judge_llm_adapter.py
+++ b/tests/test_judge_llm_adapter.py
@@ -1,0 +1,76 @@
+import json
+import types
+from pathlib import Path
+
+from judge_svc.adapter import judge_url_llm
+from judge_svc.contracts import FeatureDigest, JudgeRequest
+
+
+class FakeResp:
+    def __init__(self, text):
+        self._text = text
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"response": self._text}
+
+
+def test_judge_llm_parsing(monkeypatch):
+    # Mock requests.post so no Ollama is required
+    import judge_svc.adapter as adap
+
+    monkeypatch.setattr(
+        adap,
+        "requests",
+        types.SimpleNamespace(
+            post=lambda *a, **k: FakeResp(
+                "VERDICT: LEAN_PHISH\nSCORE: 0.82\nRATIONALE: suspicious tokens"
+            )
+        ),
+    )
+    req = JudgeRequest(
+        url="http://ex.com/login",
+        features=FeatureDigest(url_len=120, url_digit_ratio=0.22, url_subdomains=3),
+    )
+    out = judge_url_llm(req)
+    assert out.verdict == "LEAN_PHISH"
+    assert out.judge_score and 0.8 <= out.judge_score <= 0.82
+    assert "suspicious" in out.rationale
+
+
+def test_gateway_uses_backend_selector(monkeypatch, tmp_path: Path):
+    # Temporary thresholds so gateway imports cleanly
+    th = {
+        "model": "x",
+        "class_mapping": {"phish": 0, "legit": 1},
+        "calibration": {"method": "i", "cv": 5},
+        "thresholds": {
+            "t_star": 0.45,
+            "low": 0.30,
+            "high": 0.60,
+            "gray_zone_rate": 0.10,
+        },
+        "data": {"file": "x"},
+        "seed": 42,
+    }
+    p = tmp_path / "thresholds.json"
+    p.write_text(json.dumps(th), encoding="utf-8")
+    monkeypatch.setenv("THRESHOLDS_JSON", str(p))
+
+    # Force backend=llm and mock its call
+    monkeypatch.setenv("JUDGE_BACKEND", "llm")
+    import gateway.judge_wire as jw
+
+    monkeypatch.setattr(
+        jw,
+        "_JUDGE_FN",
+        lambda req: types.SimpleNamespace(
+            verdict="LEAN_LEGIT", rationale="mock", judge_score=0.2, context={}
+        ),
+    )
+    # Use the thresholds from the temp file
+    TH = {"t_star": 0.45, "low": 0.30, "high": 0.60, "gray_zone_rate": 0.10}
+    res = jw.decide_with_judge("http://foo/login", 0.45, TH)
+    assert res.final_decision in {"ALLOW", "REVIEW", "BLOCK"}  # wiring didn't crash


### PR DESCRIPTION
…dge backend selector in gateway/judge_wire.py  * Add _select_judge() function for runtime backend switching  * Support JUDGE_BACKEND environment variable (stub|llm)  * Maintain backward compatibility with stub as default- Create comprehensive environment configuration  * Add .env.example with LLM judge settings  * Support OLLAMA_HOST, JUDGE_MODEL, JUDGE_TIMEOUT_SECS  * Include MongoDB audit and thresholds configuration- Update test infrastructure for new architecture  * Fix monkeypatch targets to use _JUDGE_FN instead of judge_url  * Update LLM adapter tests for proper TH variable handling  * Maintain 100% test coverage (15/15 tests passing)- Enhance system flexibility  * Enable seamless switching between rule-based and AI-powered analysis  * Support Ollama integration with configurable models  * Preserve existing performance characteristics for stub backendTested with llama3.2:1b model showing proper decision flow:REVIEW zone -> LLM analysis -> verdict mapping -> final decisionAll pre-commit hooks passing (black, isort, flake8, mypy, bandit)